### PR TITLE
Вынос Rotate из базового класса в классы наследники

### DIFF
--- a/5_task/CMakeLists.txt
+++ b/5_task/CMakeLists.txt
@@ -35,6 +35,7 @@ if(${QT_VERSION_MAJOR} GREATER_EQUAL 6)
         house.h house.cpp
         trapezoid.h trapezoid.cpp
         rhomb.h rhomb.cpp
+        quadrilateral.h quadrilateral.cpp
     )
 # Define target properties for Android with Qt 6 as:
 #    set_property(TARGET 5_task APPEND PROPERTY QT_ANDROID_PACKAGE_SOURCE_DIR

--- a/5_task/ellipse.cpp
+++ b/5_task/ellipse.cpp
@@ -25,7 +25,7 @@ void Ellipse::SetSize(const int w, [[maybe_unused]] const int h) {
     }
 }
 
-void Ellipse::Rotate(int degrees) {
+void Ellipse::RotateEllipse(int degrees) {
     if (!circle_item_) {
         return;
     }

--- a/5_task/ellipse.h
+++ b/5_task/ellipse.h
@@ -12,7 +12,7 @@ public:
     ~Ellipse();
     void SetSize(const int w, [[maybe_unused]] const int h) override;
 
-    void Rotate(const int degrees) override;
+    void RotateEllipse(const int degrees);
 };
 
 #endif // ELLIPSE_H

--- a/5_task/figure.cpp
+++ b/5_task/figure.cpp
@@ -40,10 +40,6 @@ void Figure::Show() {
     // ...
 }
 
-void Figure::Rotate(const int degrees) {
-    // ...
-}
-
 void Figure::SetCoords(const int x, const int y){
     position_.SetX(x);
     position_.SetY(y);

--- a/5_task/figure.h
+++ b/5_task/figure.h
@@ -41,7 +41,6 @@ public:
     // то он будет использовать определение метода из базового класса
     virtual void UpdatePoints(const int dx, const int dy);
     virtual void Show();
-    virtual void Rotate(const int degrees);
 
     virtual void SetCoords(const int x, const int y);
     virtual int GetX() const;

--- a/5_task/figure.h
+++ b/5_task/figure.h
@@ -18,6 +18,7 @@ enum class FigureType{
     house_,
     trapezoid_,
     rhomb_,
+    quadrilateral_,
     all_figures_
 };
 

--- a/5_task/mainwindow.cpp
+++ b/5_task/mainwindow.cpp
@@ -44,8 +44,10 @@ MainWindow::~MainWindow()
     delete ui;
 }
 
-void MainWindow::keyPressEvent(QKeyEvent *event) {
-    if (figures_.empty()) {
+void MainWindow::keyPressEvent(QKeyEvent *event)
+{
+    if (figures_.empty())
+    {
         QMainWindow::keyPressEvent(event);
         return;
     }
@@ -54,7 +56,8 @@ void MainWindow::keyPressEvent(QKeyEvent *event) {
     int dy = 0;
 
     // Определяем направление перемещения
-    switch (event->key()) {
+    switch (event->key())
+    {
     case Qt::Key_Left: case Qt::Key_A:
         dx = -10; // Перемещение влево на 10 пикселей
         break;
@@ -71,15 +74,18 @@ void MainWindow::keyPressEvent(QKeyEvent *event) {
         return;
     }
 
-    for (auto& figure : figures_) {
-        if (MoveIsCorrect(figure->GetX(), figure->GetY(), figure->GetW(), figure->GetH(), dx, dy)) {
+    for (auto& figure : figures_)
+    {
+        if (MoveIsCorrect(figure->GetX(), figure->GetY(), figure->GetW(), figure->GetH(), dx, dy))
+        {
             figure->MoveTo(dx, dy);
         }
     }
 }
 
 // Заполняем выпадающий список доступными фигурами для выбора
-void MainWindow::FillComboBox(){
+void MainWindow::FillComboBox()
+{
     ui->comboBox->addItem("Все типы");
     ui->comboBox->setCurrentText("Все типы");
     ui->comboBox->addItem("Эллипс");
@@ -94,7 +100,8 @@ void MainWindow::FillComboBox(){
     ui->comboBox->addItem("Четырехугольник");
 }
 
-void MainWindow::SetLineEditSettings() {
+void MainWindow::SetLineEditSettings()
+{
     QList<QLineEdit*> lineEdits = findChildren<QLineEdit*>();
 
     for (QLineEdit* lineEdit : lineEdits) {
@@ -111,7 +118,8 @@ void MainWindow::SetLineEditSettings() {
     ui->lineEdit_current_h->setReadOnly(true);
 }
 
-void MainWindow::ClearLineEdit(){
+void MainWindow::ClearLineEdit()
+{
     // Проходимся по всем лейблам, в которые можно вводить текст (они имеют тип QLineEdit*),
     // и чистим их от содержимого
     QList<QLineEdit*> lineEdits = findChildren<QLineEdit*>();
@@ -122,14 +130,70 @@ void MainWindow::ClearLineEdit(){
     }
 }
 
-int MainWindow::GetRandomNumber(const int min, const int max) const {
+void MainWindow::Rotate(Figure* figure, const int degrees)
+{
+    switch (figure->GetFigureType()) {
+    case FigureType::ellipse_:
+    {
+        auto* ellipse = dynamic_cast<Ellipse*>(figure);
+        if (ellipse != nullptr)
+        {
+            ellipse->RotateEllipse(degrees);
+        }
+        break;
+    }
+    case FigureType::rectangle_:
+    {
+        auto* rectangle = dynamic_cast<Rectangle*>(figure);
+        if (rectangle != nullptr)
+        {
+            rectangle->RotateRectangle(degrees);
+        }
+        break;
+    }
+    case FigureType::trapezoid_:
+    {
+        auto* trapezoid = dynamic_cast<Trapezoid*>(figure);
+        if (trapezoid != nullptr)
+        {
+            trapezoid->RotateTrapezoid(degrees);
+        }
+        break;
+    }
+    case FigureType::rhomb_:
+    {
+        auto* rhomb = dynamic_cast<Rhomb*>(figure);
+        if (rhomb != nullptr)
+        {
+            rhomb->RotateRhomb(degrees);
+        }
+        break;
+    }
+    case FigureType::quadrilateral_:
+    {
+        auto* quadrilateral = dynamic_cast<Quadrilateral*>(figure);
+        if (quadrilateral != nullptr)
+        {
+            quadrilateral->RotateQuadrilateral(degrees);
+        }
+        break;
+    }
+    default:
+        break;
+    }
+}
+
+int MainWindow::GetRandomNumber(const int min, const int max) const
+{
    static std::mt19937 engine{ std::random_device{}() };
    std::uniform_int_distribution<int> distribution(min, max);
    return distribution(engine);
 }
 
-std::unique_ptr<Figure> MainWindow::CreateFigure(FigureType type, int x, int y, int w, int h){
-    switch (type) {
+std::unique_ptr<Figure> MainWindow::CreateFigure(FigureType type, int x, int y, int w, int h)
+{
+    switch (type)
+    {
     case FigureType::ellipse_:
         return std::make_unique<Ellipse>(scene.get(), x, y, w / 2, h / 2);
     case FigureType::circle_:
@@ -155,7 +219,8 @@ std::unique_ptr<Figure> MainWindow::CreateFigure(FigureType type, int x, int y, 
     }
 }
 
-void MainWindow::CreateRandomFigures() {
+void MainWindow::CreateRandomFigures()
+{
     size_t count = static_cast<size_t>(ui->lineEdit_count->text().toInt());
 
     if (count == 0) {
@@ -174,10 +239,12 @@ void MainWindow::CreateRandomFigures() {
         FigureType::rhomb_
     };
 
-    for (size_t i = 0; i < count; ++i) {
+    for (size_t i = 0; i < count; ++i)
+    {
         size_t index = GetRandomNumber(0, all_figure_types.size() - 1);
 
-        switch (index) {
+        switch (index)
+        {
         case 0:
             current_figure_ = std::make_unique<Ellipse>();
             current_figure_.get()->SetFigureType(FigureType::ellipse_);
@@ -218,8 +285,10 @@ void MainWindow::CreateRandomFigures() {
         // Генерация случайных координат и размеров
         auto [x, y, w, h] = GetCorrectFigure();
 
-        try {
-            if (!CoordsIsCorrect(x, y) || !SizeIsCorrect(w, h)) {
+        try
+        {
+            if (!CoordsIsCorrect(x, y) || !SizeIsCorrect(w, h))
+            {
                 QMessageBox::warning(this, "Ошибка", "Фигура выходит за пределы холста.");
                 continue;
             }
@@ -227,24 +296,29 @@ void MainWindow::CreateRandomFigures() {
             auto figure = CreateFigure(randomType, x, y, w, h);
             figure->Show();
             figures_.push_back(std::move(figure));
-        } catch (const std::exception& e) {
+        }
+        catch (const std::exception& e)
+        {
             QMessageBox::critical(this, "Ошибка", e.what());
         }
     }
     current_figure_ = nullptr;
 }
 
-bool MainWindow::CoordsIsCorrect(const int x, const int y) const{
+bool MainWindow::CoordsIsCorrect(const int x, const int y) const
+{
     return x >= 0 && x <= ui->graphicsView->width() &&
            y >= 0 && y <= ui->graphicsView->height();
 }
-bool MainWindow::SizeIsCorrect(const int w, const int h) const{
+bool MainWindow::SizeIsCorrect(const int w, const int h) const
+{
     return w > 0 && h > 0 &&
            w <= ui->graphicsView->width() &&
            h <= ui->graphicsView->height();
 }
 
-bool MainWindow::MoveIsCorrect(const int x, const int y, const int w, const int h, const int dx, const int dy) const {
+bool MainWindow::MoveIsCorrect(const int x, const int y, const int w, const int h, const int dx, const int dy) const
+{
     // Новые координаты после перемещения
     int new_x = x + dx;
     int new_y = y + dy;
@@ -256,7 +330,8 @@ bool MainWindow::MoveIsCorrect(const int x, const int y, const int w, const int 
     return is_x_valid && is_y_valid;
 }
 
-std::tuple<int, int, int, int> MainWindow::GetCorrectFigure() const {
+std::tuple<int, int, int, int> MainWindow::GetCorrectFigure() const
+{
     const int minSize = 10;
     const int maxWidth = ui->graphicsView->width();
     const int maxHeight = ui->graphicsView->height();
@@ -267,7 +342,8 @@ std::tuple<int, int, int, int> MainWindow::GetCorrectFigure() const {
     int h = 0;
 
     // Генерация случайных размеров
-    switch (current_figure_->GetFigureType()) {
+    switch (current_figure_->GetFigureType())
+    {
     case FigureType::square_:
         w = h = GetRandomNumber(minSize, std::min(maxWidth, maxHeight) / 2);
         break;
@@ -290,7 +366,8 @@ std::tuple<int, int, int, int> MainWindow::GetCorrectFigure() const {
     int maxY = ui->graphicsView->height() - h;
 
     // Для дома учитываем высоту крыши
-    if (current_figure_->GetFigureType() == FigureType::house_) {
+    if (current_figure_->GetFigureType() == FigureType::house_)
+    {
         int roofHeight = h / 2;
         maxY = std::max(0, ui->graphicsView->height() - (h + roofHeight));
     }
@@ -309,12 +386,14 @@ void MainWindow::on_comboBox_currentIndexChanged(int index)
     ui->checkBox_all_size->setCheckState(Qt::Unchecked);
     ui->checkBox_all_rotate->setCheckState(Qt::Unchecked);
 
-    if (index >= 0) {
+    if (index >= 0)
+    {
         ui->stackedWidget->setCurrentIndex(1);
     }
 
     // Используем std::make_unique для создания объекта
-    switch (index) {
+    switch (index)
+    {
     case 0:
         current_figure_.reset();
         current_figure_ = nullptr;
@@ -362,7 +441,8 @@ void MainWindow::on_comboBox_currentIndexChanged(int index)
     }
 }
 
-void MainWindow::on_pushButton_random_create_clicked() {
+void MainWindow::on_pushButton_random_create_clicked()
+{
     auto [x, y, w, h] = GetCorrectFigure();
     ui->lineEdit_count->setText(QString::number(GetRandomNumber(2, 20)));
     ui->lineEdit_x->setText(QString::number(x));
@@ -376,13 +456,16 @@ void MainWindow::on_pushButton_random_create_clicked() {
     }
 }
 
-void MainWindow::on_pushButton_ok_create_clicked() {
-    if (current_figure_ != nullptr) {
+void MainWindow::on_pushButton_ok_create_clicked()
+{
+    if (current_figure_ != nullptr)
+    {
         size_t count = static_cast<size_t>(ui->lineEdit_count->text().toInt());
 
         bool coords_and_size_ = !ui->lineEdit_x->text().isEmpty() && !ui->lineEdit_y->text().isEmpty() && !ui->lineEdit_w->text().isEmpty() && !ui->lineEdit_h->text().isEmpty();
 
-        if (count > 0 && coords_and_size_) {
+        if (count > 0 && coords_and_size_)
+        {
             bool has_been_mistakes = false;
             for (size_t i = 0; i < count; ++i) {
                 int x = ui->lineEdit_x->text().toInt();
@@ -390,100 +473,132 @@ void MainWindow::on_pushButton_ok_create_clicked() {
                 int w = ui->lineEdit_w->text().toInt();
                 int h = ui->lineEdit_h->text().toInt();
 
-                try {
+                try
+                {
                     auto new_figure = CreateFigure(current_figure_->GetFigureType(), x, y, w, h);
 
-                    if (MoveIsCorrect(x, y, w, h, 0, 0)) {
+                    if (MoveIsCorrect(x, y, w, h, 0, 0))
+                    {
                         new_figure->Show();
                         figures_.push_back(std::move(new_figure));
-                    } else {
+                    }
+                    else
+                    {
                         has_been_mistakes = true;
                     }
                 }
-                catch (const std::exception& e) {
+                catch (const std::exception& e)
+                {
                     QMessageBox::critical(this, "Ошибка", e.what());
                     return;
                 }
             }
 
-            if (has_been_mistakes) {
+            if (has_been_mistakes)
+            {
                 QMessageBox::warning(this, "Ошибка", "Некоторые фигуры с некорректными координатами не были отображены.");
             }
         }
-        else if (count > 0 && !coords_and_size_) {
-            for (size_t i = 0; i < count; ++i) {
+        else if (count > 0 && !coords_and_size_)
+        {
+            for (size_t i = 0; i < count; ++i)
+            {
                 auto [x, y, w, h] = GetCorrectFigure();
 
-                try {
+                try
+                {
                     auto new_figure = CreateFigure(current_figure_->GetFigureType(), x, y, w, h);
                     new_figure->Show();
                     figures_.push_back(std::move(new_figure));
                 }
-                catch (const std::exception& e) {
+                catch (const std::exception& e)
+                {
                     QMessageBox::critical(this, "Ошибка", e.what());
                     return;
                 }
             }
         }
     }
-    else {
+    else
+    {
         CreateRandomFigures();
     }
     ClearLineEdit();
 }
 
-void MainWindow::on_pushButton_trash_clicked() {
-    if (!figures_.empty()) {
+void MainWindow::on_pushButton_trash_clicked()
+{
+    if (!figures_.empty())
+    {
         auto it = figures_.begin();
         bool anyDeleted = false;
 
-        while (it != figures_.end()) {
-            if (current_figure_ == nullptr || typeid(**it) == typeid(*current_figure_)) {
+        while (it != figures_.end())
+        {
+            if (current_figure_ == nullptr || typeid(**it) == typeid(*current_figure_))
+            {
                 (it->get())->RemoveFromScene(); // Удаление из сцены
                 it = figures_.erase(it); // Получаем следующий итератор
                 anyDeleted = true;
                 ui->checkBox_all_size->setCheckState(Qt::Unchecked);
-            } else {
+            }
+            else
+            {
                 ++it;
             }
         }
-        if (!anyDeleted) {
+        if (!anyDeleted)
+        {
             QMessageBox::information(this, "Информация", "Фигуры указанного типа отсутствуют для удаления.");
         }
-    } else {
+    }
+    else
+    {
         QMessageBox::critical(this, "Ошибка", "Массив фигур пуст. Добавьте фигуры для удаления.");
     }
 }
 
-void MainWindow::on_pushButton_eye_clicked() {
-    if (!figures_.empty()) {
-        for (auto& figure : figures_) {
+void MainWindow::on_pushButton_eye_clicked()
+{
+    if (!figures_.empty())
+    {
+        for (auto& figure : figures_)
+        {
             // Если current_figure_ == nullptr, обрабатываем все фигуры, иначе только фигуры того же типа
-            if (current_figure_ == nullptr || figure.get()->GetFigureType() == current_figure_.get()->GetFigureType()) {
+            if (current_figure_ == nullptr || figure.get()->GetFigureType() == current_figure_.get()->GetFigureType())
+            {
                 figure->SetVisible(!figure->GetVisible());
                 figure->Show();
             }
         }
-    } else {
+    }
+    else
+    {
         QMessageBox::critical(this, "Ошибка", "Массив фигур пуст. Добавьте фигуры для обработки.");
     }
 }
 
-void MainWindow::on_pushButton_search_size_clicked() {
-    if (!figures_.empty()) {
+void MainWindow::on_pushButton_search_size_clicked()
+{
+    if (!figures_.empty())
+    {
         QString index_string = ui->lineEdit_index_size->text();
-        if (!index_string.isEmpty()) {
+        if (!index_string.isEmpty())
+        {
             bool is_found = false;
             size_t target_index = static_cast<size_t>(index_string.toInt() - 1);
             size_t current_type_count = 0;  // Счетчик для индекса конкретного типа
 
             // Если current_figure_ не установлен, просто выберем из всех фигур
-            for (size_t i = 0; i < figures_.size(); ++i) {
+            for (size_t i = 0; i < figures_.size(); ++i)
+            {
                 figures_.at(i)->SetPen(QColor(QString("#7b6f5d")), 3);
 
                 // Проверяем, если current_figure_ установлен, фильтруем по типу текущей фигуры
-                if (current_figure_ == nullptr || figures_.at(i).get()->GetFigureType() == current_figure_.get()->GetFigureType()) {
-                    if (current_type_count == target_index) {
+                if (current_figure_ == nullptr || figures_.at(i).get()->GetFigureType() == current_figure_.get()->GetFigureType())
+                {
+                    if (current_type_count == target_index)
+                    {
                         ui->lineEdit_current_x->setText(QString::number(figures_.at(i)->GetX()));
                         ui->lineEdit_current_y->setText(QString::number(figures_.at(i)->GetY()));
                         ui->lineEdit_current_w->setText(QString::number(figures_.at(i)->GetW()));
@@ -496,13 +611,18 @@ void MainWindow::on_pushButton_search_size_clicked() {
                 figures_.at(i)->Show();
             }
 
-            if (!is_found) {
+            if (!is_found)
+            {
                 QMessageBox::warning(this, "Ошибка", "Фигура с данным индексом не найдена.");
             }
-        } else {
+        }
+        else
+        {
             QMessageBox::warning(this, "Ошибка", "Введите корректный индекс.");
         }
-    } else {
+    }
+    else
+    {
         QMessageBox::critical(this, "Ошибка", "Массив фигур пуст. Добавьте фигуры для поиска.");
     }
 }
@@ -774,7 +894,7 @@ void MainWindow::on_pushButton_rotate_left_clicked() {
         for (auto& figure : figures_) {
             // Проверяем, совпадает ли тип фигуры с текущим выбранным типом (если current_figure_ не nullptr)
             if (current_figure_ == nullptr || figure->GetFigureType() == current_figure_->GetFigureType()) {
-                figure->Rotate(-90);
+                Rotate(figure.get(), -90);
             }
         }
     }
@@ -787,7 +907,7 @@ void MainWindow::on_pushButton_rotate_left_clicked() {
             // Проверяем, совпадает ли тип фигуры с текущим выбранным типом (если current_figure_ не nullptr)
             if (current_figure_ == nullptr || figures_[i]->GetFigureType() == current_figure_->GetFigureType()) {
                 if (current_type_count == target_index) {
-                    figures_[i]->Rotate(-90);
+                    Rotate(figures_[i].get(), -90);
                     break;
                 }
                 current_type_count++;
@@ -809,7 +929,7 @@ void MainWindow::on_pushButton_rotate_right_clicked()
         for (auto& figure : figures_) {
             // Проверяем, совпадает ли тип фигуры с текущим выбранным типом (если current_figure_ не nullptr)
             if (current_figure_ == nullptr || figure->GetFigureType() == current_figure_->GetFigureType()) {
-                figure->Rotate(90);
+                Rotate(figure.get(), 90);
             }
         }
     }
@@ -822,7 +942,7 @@ void MainWindow::on_pushButton_rotate_right_clicked()
             // Проверяем, совпадает ли тип фигуры с текущим выбранным типом (если current_figure_ не nullptr)
             if (current_figure_ == nullptr || figures_[i]->GetFigureType() == current_figure_->GetFigureType()) {
                 if (current_type_count == target_index) {
-                    figures_[i]->Rotate(90);
+                    Rotate(figures_[i].get(), 90);
                     break;
                 }
                 current_type_count++;

--- a/5_task/mainwindow.cpp
+++ b/5_task/mainwindow.cpp
@@ -11,6 +11,7 @@
 #include "house.h"
 #include "trapezoid.h"
 #include "rhomb.h"
+#include "quadrilateral.h"
 
 MainWindow::MainWindow(QWidget *parent)
     : QMainWindow(parent)
@@ -90,6 +91,7 @@ void MainWindow::FillComboBox(){
     ui->comboBox->addItem("Дом");
     ui->comboBox->addItem("Трапеция");
     ui->comboBox->addItem("Ромб");
+    ui->comboBox->addItem("Четырехугольник");
 }
 
 void MainWindow::SetLineEditSettings() {
@@ -146,6 +148,8 @@ std::unique_ptr<Figure> MainWindow::CreateFigure(FigureType type, int x, int y, 
         return std::make_unique<Trapezoid>(scene.get(), x, y, w, w / 2, h);
     case FigureType::rhomb_:
         return std::make_unique<Rhomb>(scene.get(), x, y, w, h);
+    case FigureType::quadrilateral_:
+        return std::make_unique<Quadrilateral>(scene.get(), x, y, w, h);
     default:
         throw std::invalid_argument("Unknown figure type");
     }
@@ -350,6 +354,10 @@ void MainWindow::on_comboBox_currentIndexChanged(int index)
     case 9:
         current_figure_ = std::make_unique<Rhomb>();
         current_figure_.get()->SetFigureType(FigureType::rhomb_);
+        break;
+    case 10:
+        current_figure_ = std::make_unique<Quadrilateral>();
+        current_figure_.get()->SetFigureType(FigureType::quadrilateral_);
         break;
     }
 }

--- a/5_task/mainwindow.h
+++ b/5_task/mainwindow.h
@@ -53,15 +53,23 @@ private slots:
 private:
     Ui::MainWindow *ui;
 
+    // Указатель на холст
     std::unique_ptr<QGraphicsScene> scene;
+
     std::unique_ptr<Figure> current_figure_;
+
+    // Вектор указателей на фигуры, которые расположены в данный момент на холсте
     std::vector<std::unique_ptr<Figure>> figures_;
 
+    // Перегрузка функции-обработчика,
+    // которая обрабатывает нажатие на кнопки (для перемещения фигур)
     void keyPressEvent(QKeyEvent *event) override;
 
     void FillComboBox();
     void SetLineEditSettings();
     void ClearLineEdit();
+
+    void Rotate(Figure* figure, const int degrees);
 
     int GetRandomNumber(const int min, const int max) const;
 

--- a/5_task/quadrilateral.cpp
+++ b/5_task/quadrilateral.cpp
@@ -56,7 +56,7 @@ bool Quadrilateral::GetVisible() const {
     return is_visible_;
 }
 
-void Quadrilateral::Rotate(const int degrees) {
+void Quadrilateral::RotateQuadrilateral(const int degrees) {
     if (!rect_item_) return;
 
     qreal previous_rotation = rect_item_->rotation();

--- a/5_task/quadrilateral.cpp
+++ b/5_task/quadrilateral.cpp
@@ -1,0 +1,112 @@
+#include "quadrilateral.h"
+
+Quadrilateral::Quadrilateral()
+    : Figure(), rect_item_(nullptr) {}
+
+Quadrilateral::Quadrilateral(QGraphicsScene* scene, int x, int y, int w, int h, const QPen& pen, const FigureType& figure_type)
+    : Figure(scene, {x, y}, w, h, pen, 3, figure_type)
+{
+    rect_item_ = new QGraphicsRectItem(0, 0, w, h);
+    rect_item_->setPen(pen);
+    SetFigureType(figure_type);
+}
+
+Quadrilateral::~Quadrilateral() {
+    if (rect_item_) {
+        delete rect_item_;
+    }
+}
+
+// void Quadrilateral::MoveTo(const int dx, const int dy) {
+//     position_.MoveToX(dx);
+//     position_.MoveToY(dy);
+//     if (rect_item_) {
+//         rect_item_->setPos(position_.GetX(), position_.GetY());
+//     }
+// }
+
+void Quadrilateral::Show() {
+    if (!rect_item_) {
+        rect_item_ = new QGraphicsRectItem(0, 0, w_, h_);
+    }
+    if (rect_item_ && !rect_item_->scene()) {
+        scene_->addItem(rect_item_);
+    }
+    rect_item_->setPos(position_.GetX(), position_.GetY());
+    rect_item_->setPen(pen_);
+    rect_item_->setVisible(is_visible_);
+}
+
+void Quadrilateral::RemoveFromScene() {
+    if (rect_item_ && scene_->items().contains(rect_item_)) {
+        scene_->removeItem(rect_item_);
+        delete rect_item_;
+        rect_item_ = nullptr;
+    }
+}
+
+void Quadrilateral::SetVisible(bool visible) {
+    is_visible_ = visible;
+    if (rect_item_) {
+        rect_item_->setVisible(visible);
+    }
+}
+
+bool Quadrilateral::GetVisible() const {
+    return is_visible_;
+}
+
+void Quadrilateral::Rotate(const int degrees) {
+    if (!rect_item_) return;
+
+    qreal previous_rotation = rect_item_->rotation();
+    rect_item_->setRotation(previous_rotation + degrees);
+
+    QRectF global_bounds = rect_item_->mapToScene(rect_item_->boundingRect()).boundingRect();
+    QRectF scene_bounds = scene_->sceneRect();
+
+    if (!scene_bounds.contains(global_bounds)) {
+        rect_item_->setRotation(previous_rotation);
+    }
+}
+
+void Quadrilateral::SetCoords(const int x, const int y) {
+    position_.SetX(x);
+    position_.SetY(y);
+}
+
+int Quadrilateral::GetX() const {
+    return position_.GetX();
+}
+
+int Quadrilateral::GetY() const {
+    return position_.GetY();
+}
+
+void Quadrilateral::SetSize(const int w, const int h) {
+    w_ = w;
+    h_ = h;
+    if (rect_item_) {
+        rect_item_->setRect(0, 0, w_, h_);
+    }
+}
+
+int Quadrilateral::GetW() const {
+    return w_;
+}
+
+int Quadrilateral::GetH() const {
+    return h_;
+}
+
+void Quadrilateral::SetPen(const QPen& pen, const int pen_width) {
+    pen_ = pen;
+    pen_.setWidth(pen_width);
+    if (rect_item_) {
+        rect_item_->setPen(pen_);
+    }
+}
+
+QPen Quadrilateral::GetPen() const {
+    return pen_;
+}

--- a/5_task/quadrilateral.h
+++ b/5_task/quadrilateral.h
@@ -19,7 +19,7 @@ public:
     void SetVisible(bool visible) override;
     bool GetVisible() const override;
 
-    void Rotate(const int degrees) override;
+    void RotateQuadrilateral(const int degrees);
 
     void SetCoords(const int x, const int y) override;
     int GetX() const override;

--- a/5_task/quadrilateral.h
+++ b/5_task/quadrilateral.h
@@ -1,0 +1,39 @@
+#ifndef QUADRILATERAL_H
+#define QUADRILATERAL_H
+
+#include "figure.h"
+#include <QGraphicsRectItem>
+#include <QGraphicsScene>
+
+class Quadrilateral : public Figure {
+public:
+    Quadrilateral();
+    Quadrilateral(QGraphicsScene* scene, int x, int y, int width, int height,
+                  const QPen& pen = QPen(QColor("#7b6f5d")),
+                  const FigureType& figure_type = FigureType::quadrilateral_);
+    ~Quadrilateral();
+
+    // Реализация виртуальных методов
+    void Show() override;
+    void RemoveFromScene() override;
+    void SetVisible(bool visible) override;
+    bool GetVisible() const override;
+
+    void Rotate(const int degrees) override;
+
+    void SetCoords(const int x, const int y) override;
+    int GetX() const override;
+    int GetY() const override;
+
+    void SetSize(const int w, const int h) override;
+    int GetW() const override;
+    int GetH() const override;
+
+    void SetPen(const QPen& pen, const int pen_width) override;
+    QPen GetPen() const override;
+
+protected:
+    QGraphicsRectItem* rect_item_;
+};
+
+#endif // QUADRILATERAL_H

--- a/5_task/rectangle.cpp
+++ b/5_task/rectangle.cpp
@@ -3,7 +3,7 @@
 Rectangle::Rectangle() = default;
 
 Rectangle::Rectangle(QGraphicsScene* scene, int x, int y, int w, int h, const QPen& pen, const FigureType& figure_type)
-    : Figure(scene, {x, y}, w, h, pen, 3, figure_type)
+    : Quadrilateral(scene, x, y, w, h, pen, figure_type)
 {
     rect_item_ = new QGraphicsRectItem(0, 0, w, h);
     rect_item_->setPen(pen);

--- a/5_task/rectangle.cpp
+++ b/5_task/rectangle.cpp
@@ -40,7 +40,7 @@ void Rectangle::RemoveFromScene() {
     }
 }
 
-void Rectangle::Rotate(const int degrees) {
+void Rectangle::RotateRectangle(const int degrees) {
     if (!rect_item_) {
         return;
     }

--- a/5_task/rectangle.h
+++ b/5_task/rectangle.h
@@ -18,7 +18,7 @@ public:
     void Show() override;
     void RemoveFromScene() override;
 
-    void Rotate(const int degrees) override;
+    void RotateRectangle(const int degrees);
 
 protected:
     QGraphicsRectItem* rect_item_;

--- a/5_task/rectangle.h
+++ b/5_task/rectangle.h
@@ -2,13 +2,13 @@
 #define RECTANGLE_H
 #pragma once
 
-#include "figure.h"
+#include "quadrilateral.h"
 
 #include <QGraphicsScene>
 #include <QGraphicsRectItem>
 #include <QPen>
 
-class Rectangle : public Figure {
+class Rectangle : public Quadrilateral {
 public:
     Rectangle();
     Rectangle(QGraphicsScene* scene, int x, int y, int width, int height, const QPen& pen = QPen(QColor(123, 111, 93), 3), const FigureType& figure_type = FigureType::rectangle_);

--- a/5_task/rhomb.cpp
+++ b/5_task/rhomb.cpp
@@ -1,14 +1,14 @@
 #include "rhomb.h"
 
 Rhomb::Rhomb()
-    : Rectangle()
+    : Quadrilateral()
     , side_(0)
     , height_(0)
     , rhomb_item_(nullptr)
 {}
 
 Rhomb::Rhomb(QGraphicsScene* scene, int x, int y, int side, int height, const QPen& pen, const FigureType& figure_type)
-    : Rectangle(scene, x, y, side, height, pen, figure_type), side_(side), height_(height) {
+    : Quadrilateral(scene, x, y, side, height, pen, figure_type), side_(side), height_(height) {
     rhomb_item_ = new QGraphicsPolygonItem();
     SetFigureType(FigureType::rhomb_);
     SetSize(side, height);

--- a/5_task/rhomb.cpp
+++ b/5_task/rhomb.cpp
@@ -59,7 +59,7 @@ void Rhomb::RemoveFromScene() {
     }
 }
 
-void Rhomb::Rotate(const int degrees) {
+void Rhomb::RotateRhomb(const int degrees) {
     if (!rhomb_item_) {
         return;
     }

--- a/5_task/rhomb.h
+++ b/5_task/rhomb.h
@@ -14,7 +14,7 @@ public:
     void Show() override;
     void RemoveFromScene() override;
 
-    void Rotate(const int degrees) override;
+    void RotateRhomb(const int degrees);
 
 protected:
     QGraphicsPolygonItem* rhomb_item_;

--- a/5_task/rhomb.h
+++ b/5_task/rhomb.h
@@ -1,10 +1,10 @@
 #ifndef Rhomb_H
 #define Rhomb_H
 
-#include "rectangle.h"
+#include "quadrilateral.h"
 #include <QGraphicsPolygonItem>
 
-class Rhomb : public Rectangle {
+class Rhomb : public Quadrilateral {
 public:
     Rhomb();
     Rhomb(QGraphicsScene* scene, int x, int y, int side, int height, const QPen& pen = QPen(QColor(123, 111, 93), 3), const FigureType& figure_type = FigureType::rhomb_);

--- a/5_task/square.cpp
+++ b/5_task/square.cpp
@@ -3,7 +3,7 @@
 Square::Square() = default;
 
 Square::Square(QGraphicsScene* scene, int x, int y, int w, const QPen& pen)
-    : Rectangle(scene, x, y, w, w, pen, FigureType::square_)
+    : Quadrilateral(scene, x, y, w, w, pen, FigureType::square_)
 {
     rect_item_ = new QGraphicsRectItem(0, 0, w, w);
     rect_item_->setPen(pen);

--- a/5_task/square.h
+++ b/5_task/square.h
@@ -2,9 +2,9 @@
 #define SQUARE_H
 #pragma once
 
-#include "rectangle.h"
+#include "quadrilateral.h"
 
-class Square : public Rectangle {
+class Square : public Quadrilateral {
 public:
     Square();
     Square(QGraphicsScene* scene, int x, int y, int width, const QPen& pen = QPen(QColor(123, 111, 93), 3));

--- a/5_task/trapezoid.cpp
+++ b/5_task/trapezoid.cpp
@@ -1,7 +1,7 @@
 #include "trapezoid.h"
 
 Trapezoid::Trapezoid()
-    : Rectangle()
+    : Quadrilateral()
     , base1_(0)
     , base2_(0)
     , height_(0)
@@ -9,7 +9,7 @@ Trapezoid::Trapezoid()
 {}
 
 Trapezoid::Trapezoid(QGraphicsScene* scene, int x, int y, int base1, int base2, int height, const QPen& pen, const FigureType& figure_type)
-    : Rectangle(scene, x, y, base1, height, pen, figure_type), base1_(base1), base2_(base2), height_(height) {
+    : Quadrilateral(scene, x, y, base1, height, pen, figure_type), base1_(base1), base2_(base2), height_(height) {
     trapezoid_item_ = new QGraphicsPolygonItem();
     SetFigureType(FigureType::trapezoid_);
     SetSize(base1, base2, height);

--- a/5_task/trapezoid.cpp
+++ b/5_task/trapezoid.cpp
@@ -61,7 +61,7 @@ void Trapezoid::RemoveFromScene() {
     }
 }
 
-void Trapezoid::Rotate(const int degrees) {
+void Trapezoid::RotateTrapezoid(const int degrees) {
     if (!trapezoid_item_) {
         return;
     }

--- a/5_task/trapezoid.h
+++ b/5_task/trapezoid.h
@@ -15,7 +15,7 @@ public:
     void Show() override;
     void RemoveFromScene() override;
 
-    void Rotate(const int degrees) override;
+    void RotateTrapezoid(const int degrees);
 
 protected:
     QGraphicsPolygonItem* trapezoid_item_;

--- a/5_task/trapezoid.h
+++ b/5_task/trapezoid.h
@@ -1,10 +1,10 @@
 #ifndef TRAPEZOID_H
 #define TRAPEZOID_H
 
-#include "rectangle.h"
+#include "quadrilateral.h"
 #include <QGraphicsPolygonItem>
 
-class Trapezoid : public Rectangle {
+class Trapezoid : public Quadrilateral {
 public:
     Trapezoid();
     Trapezoid(QGraphicsScene* scene, int x, int y, int base1, int base2, int height, const QPen& pen = QPen(QColor(123, 111, 93), 3), const FigureType& figure_type = FigureType::trapezoid_);


### PR DESCRIPTION
- Метод Rotate вынесен из базового класса Figure и находится отдельно у каждой фигуры, которая предусматривает поворот фигуры.
- За поворот фигур отмечает функция MainWindow::Rotate.